### PR TITLE
feat: 更新包子漫画域名为cn.baozimhcn.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ npm run build
 | 最漫画         | https://www.zuimh.com/          |
 | 六漫画         | http://www.6mh1.com/          |
 | 漫画芯         | https://www.mhxin.com/          |
-| 包子漫画        | https://cn.baozimh.com/         |
+| 包子漫画        | https://cn.baozimhcn.com/         |
 | 爱国漫         | https://www.guoman.net/       |
 | 最次元         | https://zcymh.com/       |
 | 看漫画        | https://www.kanman.com/   |

--- a/src/utils/comics.js
+++ b/src/utils/comics.js
@@ -1105,8 +1105,8 @@ export const comicsWebInfo = [
     }
   },
   {
-    domain: ['cn.baozimhcn.com', 'WWW.baozimhcn.com'],
-    homepage: 'https://cn.baozimhcn.com/',
+    domain: ['www.baozimhcn.com', 'www.baozimh.com'],
+    homepage: 'https://www.baozimh.com/',
     webName: '包子漫画',
     comicNameCss: 'h1.comics-detail__title',
     chapterCss: '.comics-detail > .l-content:nth-of-type(3) #chapter-items',

--- a/src/utils/comics.js
+++ b/src/utils/comics.js
@@ -1105,8 +1105,8 @@ export const comicsWebInfo = [
     }
   },
   {
-    domain: ['cn.baozimh.com', 'WWW.baozimh.com'],
-    homepage: 'https://cn.baozimh.com/',
+    domain: ['cn.baozimhcn.com', 'WWW.baozimhcn.com'],
+    homepage: 'https://cn.baozimhcn.com/',
     webName: '包子漫画',
     comicNameCss: 'h1.comics-detail__title',
     chapterCss: '.comics-detail > .l-content:nth-of-type(3) #chapter-items',

--- a/tampermonkey.md
+++ b/tampermonkey.md
@@ -101,7 +101,7 @@
 | 最漫画         | https://www.zuimh.com/          |                             |
 | 六漫画         | http://www.6mh1.com/          |                             |
 | 漫画芯         | https://www.mhxin.com/          |                             |
-| 包子漫画        | https://cn.baozimh.com/         |                             |
+| 包子漫画        | https://cn.baozimhcn.com/         |                             |
 | 爱国漫         | https://www.guoman.net/       |                              |
 | 最次元         | https://zcymh.com/       |                               |
 | 看漫画        | https://www.kanman.com/   |                             |


### PR DESCRIPTION
# 说明

包子漫画原地址 `cn.baozimh.com` 失效。现替换为新地址 `www.baozimhcn.com`

替换后测试下载正常