### PR TITLE
feat: 替换全局样式为LESS格式，移除SCSS相关依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
     "html-webpack-plugin": "^4.5.0",
     "less": "^4.1.3",
     "less-loader": "^11.0.0",
-    "node-sass": "^8.0.0",
-    "sass-loader": "^12.0.0",
     "style-loader": "^3.0.0",
     "vue-loader": "^15.9.5",
     "vue-template-compiler": "^2.6.12",

--- a/src/app.vue
+++ b/src/app.vue
@@ -123,7 +123,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="less" scoped>
 * {
   margin: 0;
   padding: 0;
@@ -149,8 +149,6 @@ export default {
 <style lang="less" scoped>
 .yi-ling-app {
   position: fixed;
-  // width: 100%;
-  // height: 100%;
   z-index: 100000;
 
   #app-right {
@@ -208,7 +206,6 @@ export default {
   }
 }
 .card--hide {
-  // right: -@appWidth !important;
   transform: translate(100%, -50%)  !important;
   .card__btn {
     svg {

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@
 import Vue from 'vue'
 import App from './app.vue'
 
-import './styles/global.scss'
+import './styles/global_scss.less'
 import './styles/global.less'
 
 import { isDev } from './config'

--- a/src/styles/global_scss.less
+++ b/src/styles/global_scss.less
@@ -1,4 +1,6 @@
-$scrollbarColor: #66ccff88;
+// 原 global.scss 转换为 global_scss.less 
+
+@scrollbarColor: #66ccff88;
 
 .yi-ling-app {
   * {
@@ -22,7 +24,7 @@ $scrollbarColor: #66ccff88;
   }
   ::-webkit-scrollbar-thumb:vertical {
     height: 5px;
-    background-color: $scrollbarColor;
+    background-color: @scrollbarColor;
     border-radius: 15px;
     -webkit-border-radius:  15px;
   }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -33,14 +33,6 @@ module.exports = () => {
           ]
         },
         {
-          test: /\.scss$/,
-          use: [
-            'style-loader',
-            'css-loader',
-            'sass-loader'
-          ]
-        },
-        {
           test: /\.less$/i,
           use: [
             'style-loader',
@@ -68,10 +60,9 @@ module.exports = () => {
           loader: 'vue-loader',
           options: {
             loaders: {
-              'scss': [
+              'less': [
                 'style-loader',
                 'css-loader',
-                'sass-loader',
                 'less-loader'
               ]
             }


### PR DESCRIPTION
# 说明

- node-sass 库经已停止积极维护。保留其作为依赖将导致 npm 无法正确安装依赖。长期保留此依赖在高版本 Node.js 环境中可能引发兼容性问题，并导致潜在的构建错误。
- 当前项目技术栈中同时存在 SCSS 和 LESS 两种样式预处理器，这造成了不必要的冗余和潜在问题。鉴于项目现状主要采用 LESS 进行样式开发，且未充分利用 SCSS 的特定高级特性，移除 SCSS 相关依赖并统一使用 LESS 更具合理性。